### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+.env
+*.log
+*.mp4
+*.webm
+*.mkv
+*.mov
+/tmp/
+.venv/
+venv/
+quality_store.json


### PR DESCRIPTION
Feature: Per-chat /quality, softer format fallbacks, send-as-document fallback

This PR adds three key improvements:

Per-chat /quality command

Users can set 360, 480, or 720 once per chat.

Stored in a tiny JSON file quality_store.json (ignored by Git).

Defaults to 720 when ffmpeg is available, otherwise 480.

Command:

/quality → shows current setting + usage

/quality 360 (or 480, 720) → saves preference for that chat

Softer format fallbacks

Preferred format is chosen from the quality preset.

If the requested format is unavailable or size would exceed Telegram limits, automatically downshifts (e.g., 480→360) and finally tries a generic best format.

Reduces “Requested format is not available” and “too large” errors.

Send-as-document fallback

If reply_video fails for any reason (container/codec issue, unsupported streaming), the bot automatically retries with reply_document.

Ensures users still receive the file even if it can’t be streamed in Telegram.

Notes

Filesystem on Railway is ephemeral; the JSON store is best-effort.

No changes to Dockerfile or requirements.

.gitignore updated to exclude quality_store.json and other local/runtime files.